### PR TITLE
Hide Private Subreddits From Visualization Labels

### DIFF
--- a/src/lib/components/Tooltip.svelte
+++ b/src/lib/components/Tooltip.svelte
@@ -141,25 +141,23 @@
   >
     <section>
       <h2>
-        {#if currentBadge === "public"}
-          <sl-badge variant="primary" pill>
-            Public
-          </sl-badge>
-        {:else if currentBadge === "nsfw"}
+        {#if currentBadge === "nsfw"}
           <sl-badge variant="warning" pill>
             NSFW
           </sl-badge>
+          {currentName}
         {:else if currentBadge ===  "banned"}
           <sl-badge variant="danger" pill>
             Banned
           </sl-badge>
+          {currentName}
         {:else if currentBadge === "private"}
           <sl-badge variant="neutral" pill>
             Private
           </sl-badge>
+        {:else}
+          {currentName}
         {/if}
-
-        {currentName}
       </h2>
     
       <h3>Size Metadata</h3>

--- a/src/lib/helpers/treemap/methods/render.js
+++ b/src/lib/helpers/treemap/methods/render.js
@@ -29,6 +29,14 @@ const drawLeaf = function ( leaf ) {
 };
 
 const labelLeaf = function ( leaf ) {
+  if (leaf.data.displayLabel === "Dankchristianmemes2") {
+    console.log( leaf.data );
+  }
+
+  if ( leaf.data.isPrivate === true ) {
+    return;
+  }
+
   const x0 = this.scaleX( leaf.x0 );
   const x1 = this.scaleX( leaf.x1 );
   const y0 = this.scaleY( leaf.y0 );


### PR DESCRIPTION
drawing on recent changes to tree structure, we're now hiding labels for private subreddits in the treemap